### PR TITLE
Add Gradle convention plugin for a KMP library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlin.library) apply false
     alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.kotlin.multiplatform) apply false
 }
 
 // Root build.gradle.kts

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,15 +1,10 @@
 plugins {
-    alias(libs.plugins.custom.kotlin.multiplatform.library.convention)
+    alias(libs.plugins.custom.library.convention)
 }
 
-kotlin {
-    sourceSets {
-        commonMain {
-            dependencies {
-                // Library dependencies
-                implementation(libs.kotlinx.coroutines.android)
-                implementation(libs.koin.core)
-            }
-        }
-    }
+dependencies {
+
+    // Library dependencies
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.koin.core)
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -2,8 +2,14 @@ plugins {
     alias(libs.plugins.custom.kotlin.multiplatform.library.convention)
 }
 
-dependencies {
-    // Library dependencies
-    implementation(libs.kotlinx.coroutines.android)
-    implementation(libs.koin.core)
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                // Library dependencies
+                implementation(libs.kotlinx.coroutines.android)
+                implementation(libs.koin.core)
+            }
+        }
+    }
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,9 +1,8 @@
 plugins {
-    alias(libs.plugins.custom.library.convention)
+    alias(libs.plugins.custom.kotlin.multiplatform.library.convention)
 }
 
 dependencies {
-
     // Library dependencies
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.koin.core)

--- a/gradle-plugins/convention-plugins/build.gradle.kts
+++ b/gradle-plugins/convention-plugins/build.gradle.kts
@@ -28,6 +28,10 @@ gradlePlugin {
             id = "android.template.test"
             implementationClass = "AndroidTestConventionPlugin"
         }
+        register("kotlinMultiplatformLibraryConvention") {
+            id = "kotlin.multiplatform.library.convention"
+            implementationClass = "KMPLibraryConventionPlugin"
+        }
     }
 }
 

--- a/gradle-plugins/convention-plugins/src/main/kotlin/KMPLibraryConventionPlugin.kt
+++ b/gradle-plugins/convention-plugins/src/main/kotlin/KMPLibraryConventionPlugin.kt
@@ -4,7 +4,6 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.the
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinTargetContainerWithPresetFunctions
 
 class KMPLibraryConventionPlugin : Plugin<Project> {
   override fun apply(target: Project) {
@@ -17,7 +16,11 @@ class KMPLibraryConventionPlugin : Plugin<Project> {
 
       extensions.configure<KotlinMultiplatformExtension> {
         androidTarget()
-        iosX64()
+        applyDefaultHierarchyTemplate()
+
+        with(sourceSets) {
+          listOf(iosMain, iosTest, androidMain).forEach { it.get().dependsOn(sourceSets.commonMain.get()) }
+        }
       }
     }
   }

--- a/gradle-plugins/convention-plugins/src/main/kotlin/KMPLibraryConventionPlugin.kt
+++ b/gradle-plugins/convention-plugins/src/main/kotlin/KMPLibraryConventionPlugin.kt
@@ -1,0 +1,23 @@
+import org.gradle.accessors.dm.LibrariesForLibs
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.the
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinTargetContainerWithPresetFunctions
+
+class KMPLibraryConventionPlugin : Plugin<Project> {
+  override fun apply(target: Project) {
+    with(target) {
+      val libs = the<LibrariesForLibs>()
+      with(pluginManager) {
+        apply(libs.plugins.kotlin.multiplatform.get().pluginId)
+        apply(libs.plugins.android.library.get().pluginId)
+      }
+
+      extensions.configure<KotlinMultiplatformExtension> {
+        androidTarget()
+      }
+    }
+  }
+}

--- a/gradle-plugins/convention-plugins/src/main/kotlin/KMPLibraryConventionPlugin.kt
+++ b/gradle-plugins/convention-plugins/src/main/kotlin/KMPLibraryConventionPlugin.kt
@@ -18,11 +18,10 @@ class KMPLibraryConventionPlugin : Plugin<Project> {
 
       extensions.configure<KotlinMultiplatformExtension> {
         androidTarget()
+        iosX64()
+        iosArm64()
+        iosSimulatorArm64()
         applyDefaultHierarchyTemplate()
-
-        with(sourceSets) {
-          listOf(iosMain, iosTest, androidMain).forEach { it.get().dependsOn(sourceSets.commonMain.get()) }
-        }
       }
 
       extensions.configure<LibraryExtension> {

--- a/gradle-plugins/convention-plugins/src/main/kotlin/KMPLibraryConventionPlugin.kt
+++ b/gradle-plugins/convention-plugins/src/main/kotlin/KMPLibraryConventionPlugin.kt
@@ -17,6 +17,7 @@ class KMPLibraryConventionPlugin : Plugin<Project> {
 
       extensions.configure<KotlinMultiplatformExtension> {
         androidTarget()
+        iosX64()
       }
     }
   }

--- a/gradle-plugins/convention-plugins/src/main/kotlin/KMPLibraryConventionPlugin.kt
+++ b/gradle-plugins/convention-plugins/src/main/kotlin/KMPLibraryConventionPlugin.kt
@@ -1,3 +1,5 @@
+import android.template.gradle.convention.plugins.common.configureAndroid
+import com.android.build.gradle.LibraryExtension
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -21,6 +23,11 @@ class KMPLibraryConventionPlugin : Plugin<Project> {
         with(sourceSets) {
           listOf(iosMain, iosTest, androidMain).forEach { it.get().dependsOn(sourceSets.commonMain.get()) }
         }
+      }
+
+      extensions.configure<LibraryExtension> {
+        this@with.configureAndroid(this)
+        defaultConfig.consumerProguardFile("consumer-rules.pro")
       }
     }
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", vers
 kotlin-parcelize = { id = "kotlin-parcelize", version.ref = "kotlinParcelize" }
 jacoco = { id = "org.gradle.jacoco", version.ref = "jacoco" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 
 # Custom plugins
 custom-application-convention = { id = "android.template.application", version.ref = "customPlugins" }
@@ -93,3 +94,4 @@ custom-library-with-compose-convention = { id = "android.template.library.with.c
 custom-ksp-convention = { id = "android.template.ksp", version.ref = "customPlugins" }
 kotlin-compiler-convention = { id = "android.template.kotlin.compiler", version.ref = "customPlugins" }
 test-convention = { id = "android.template.test", version.ref = "customPlugins" }
+custom-kotlin-multiplatform-library-convention = { id = "kotlin.multiplatform.library.convention", version.ref = "customPlugins" }


### PR DESCRIPTION
# Summary
This PR adds a new Gradle convention plugin to setup and configure the targets and `sourceSet` relations for a KMP library. It's currently supporting the following targets:
- `android` through `androidTarget`
- Both iOS architectures (through `iosX64` and `iosArm64`)
- iOS simulator through `iosSimulatorArm64`

The convention plugin can now be applied in any library using:

```Gradle
// In the build.gradle.kts file
plugins {
  alias(libs.plugins.custom.kotlin.multiplatform.library.convention)
}